### PR TITLE
Add GPIO button input for ESP32

### DIFF
--- a/esp_8_bit.ino
+++ b/esp_8_bit.ino
@@ -21,6 +21,7 @@
 #define PERF  // some stats about where we spend our time
 #include "src/emu.h"
 #include "src/video_out.h"
+#include "src/gpio_input.h"
 
 // esp_8_bit
 // Atari 8 computers, NES and SMS game consoles on your TV with nothing more than a ESP32 and a sense of nostalgia
@@ -116,6 +117,7 @@ void setup()
   mount_filesystem();                       // mount the filesystem!
   _emu = NewEmulator();                     // create the emulator!
   hid_init("emu32");                        // bluetooth hid on core 1!
+  gpio_input_init();                         // initialize GPIO buttons
 
   #ifdef SINGLE_CORE
   emu_init();

--- a/src/emu.h
+++ b/src/emu.h
@@ -149,6 +149,7 @@ extern "C" int unpack(const char* dst_path, const uint8_t* d, int len);
 
 void audio_write_16(const int16_t* s, int len, int channels);
 int get_hid_ir(uint8_t* dst);
+int get_hid_all(uint8_t* dst);
 uint32_t generic_map(uint32_t m, const uint32_t* target);
 
 Emu* NewAtari800(int ntsc = 1);

--- a/src/gpio_input.cpp
+++ b/src/gpio_input.cpp
@@ -1,0 +1,73 @@
+#include "gpio_input.h"
+#include "emu.h"
+
+#ifdef ESP_PLATFORM
+#include "driver/gpio.h"
+
+static gpio_button_state _gpio_buttons = {0};
+
+void gpio_input_init() {
+    gpio_config_t io_conf = {};
+    io_conf.pin_bit_mask = (1ULL << GPIO_BTN_A) | (1ULL << GPIO_BTN_B) |
+                           (1ULL << GPIO_BTN_SELECT) | (1ULL << GPIO_BTN_START) |
+                           (1ULL << GPIO_BTN_UP) | (1ULL << GPIO_BTN_DOWN) |
+                           (1ULL << GPIO_BTN_LEFT) | (1ULL << GPIO_BTN_RIGHT);
+    io_conf.mode = GPIO_MODE_INPUT;
+    io_conf.pull_up_en = GPIO_PULLUP_ENABLE;
+    io_conf.pull_down_en = GPIO_PULLDOWN_DISABLE;
+    io_conf.intr_type = GPIO_INTR_DISABLE;
+    gpio_config(&io_conf);
+}
+
+int get_hid_gpio(uint8_t* dst) {
+    uint16_t buttons = 0;
+    if (!gpio_get_level(GPIO_BTN_A))      buttons |= GENERIC_FIRE_A;
+    if (!gpio_get_level(GPIO_BTN_B))      buttons |= GENERIC_FIRE_B;
+    if (!gpio_get_level(GPIO_BTN_SELECT)) buttons |= GENERIC_SELECT;
+    if (!gpio_get_level(GPIO_BTN_START))  buttons |= GENERIC_START;
+    if (!gpio_get_level(GPIO_BTN_UP))     buttons |= GENERIC_UP;
+    if (!gpio_get_level(GPIO_BTN_DOWN))   buttons |= GENERIC_DOWN;
+    if (!gpio_get_level(GPIO_BTN_LEFT))   buttons |= GENERIC_LEFT;
+    if (!gpio_get_level(GPIO_BTN_RIGHT))  buttons |= GENERIC_RIGHT;
+
+    if (buttons != _gpio_buttons.current_state) {
+        _gpio_buttons.debounce_timer = 3;
+        _gpio_buttons.current_state = buttons;
+    }
+
+    if (_gpio_buttons.debounce_timer > 0) {
+        _gpio_buttons.debounce_timer--;
+        return 0;
+    }
+
+    if (buttons != _gpio_buttons.last_state) {
+        _gpio_buttons.last_state = buttons;
+        dst[0] = 0xA1;
+        dst[1] = 0x42;
+        dst[2] = buttons & 0xFF;
+        dst[3] = buttons >> 8;
+        dst[4] = 0;
+        dst[5] = 0;
+        return 6;
+    }
+    return 0;
+}
+#else
+
+void gpio_input_init() {}
+
+int get_hid_gpio(uint8_t* dst) {
+    (void)dst;
+    return 0;
+}
+
+#endif // ESP_PLATFORM
+
+int get_hid_all(uint8_t* dst) {
+    int n = 0;
+    if ((n = get_hid_gpio(dst)))
+        return n;
+    if ((n = get_hid_ir(dst)))
+        return n;
+    return 0;
+}

--- a/src/gpio_input.h
+++ b/src/gpio_input.h
@@ -1,0 +1,27 @@
+#ifndef GPIO_INPUT_H
+#define GPIO_INPUT_H
+
+#include <stdint.h>
+
+// GPIO pin definitions for buttons
+// These are raw GPIO numbers to avoid depending on ESP-IDF headers
+#define GPIO_BTN_A      21
+#define GPIO_BTN_B      22
+#define GPIO_BTN_SELECT 23
+#define GPIO_BTN_START  19
+#define GPIO_BTN_UP     18
+#define GPIO_BTN_DOWN   5
+#define GPIO_BTN_LEFT   17
+#define GPIO_BTN_RIGHT  16
+
+// Button state tracking
+struct gpio_button_state {
+    uint16_t current_state;
+    uint16_t last_state;
+    uint8_t debounce_timer;
+};
+
+void gpio_input_init();
+int get_hid_gpio(uint8_t* dst);
+
+#endif // GPIO_INPUT_H

--- a/src/gui.cpp
+++ b/src/gui.cpp
@@ -1011,7 +1011,7 @@ void gui_update()
     if (n > 0)
         gui_hid(buf,n);
     
-    n = get_hid_ir(buf);
+    n = get_hid_all(buf);
     if (n > 0)
         gui_hid(buf,n);
 }


### PR DESCRIPTION
## Summary
- add GPIO-based button handler to generate HID reports
- poll GPIO buttons before IR inputs
- initialize GPIO buttons during setup
- guard GPIO input code so non-ESP builds compile

## Testing
- `make` *(fails: No targets specified and no makefile found)*
- `g++ -std=c++11 -c src/gpio_input.cpp -I.`

------
https://chatgpt.com/codex/tasks/task_e_68b6fed2085c8323a48429975b5e96de