### PR TITLE
Add MIDI control for buttons and glitch parameter

### DIFF
--- a/esp_8_bit.ino
+++ b/esp_8_bit.ino
@@ -23,6 +23,7 @@
 #include "src/video_out.h"
 #include "src/gpio_input.h"
 #include "src/analog_glitch.h"
+#include "src/midi_input.h"
 
 // esp_8_bit
 // Atari 8 computers, NES and SMS game consoles on your TV with nothing more than a ESP32 and a sense of nostalgia
@@ -120,6 +121,7 @@ void setup()
   hid_init("emu32");                        // bluetooth hid on core 1!
   gpio_input_init();                        // initialize gpio button inputs
   analog_glitch_init();                     // initialize analog glitch control
+  midi_input_init();                        // initialize MIDI input
 
   #ifdef SINGLE_CORE
   emu_init();

--- a/src/analog_glitch.cpp
+++ b/src/analog_glitch.cpp
@@ -42,6 +42,15 @@ static void update_glitch_mask(uint8_t slot) {
     }
 }
 
+void analog_glitch_set_slot(uint8_t slot) {
+    if (slot > GLITCH_MAX_PINS) {
+        slot = GLITCH_MAX_PINS;
+    }
+    _glitch_state.current_slot = slot;
+    _glitch_state.last_slot = slot;
+    update_glitch_mask(slot);
+}
+
 void analog_glitch_update() {
     _debug_call_count++;
     
@@ -144,6 +153,7 @@ void analog_glitch_init() {
 }
 
 void analog_glitch_update() {}
+void analog_glitch_set_slot(uint8_t slot) { (void)slot; }
 
 uint8_t get_glitch_slot() {
     return 0;

--- a/src/analog_glitch.h
+++ b/src/analog_glitch.h
@@ -33,6 +33,7 @@ extern "C" {
 
 void analog_glitch_init();
 void analog_glitch_update();
+void analog_glitch_set_slot(uint8_t slot);
 uint8_t get_glitch_slot();
 bool is_glitch_enabled();
 void set_glitch_enabled(bool enabled);

--- a/src/gpio_input.cpp
+++ b/src/gpio_input.cpp
@@ -1,5 +1,6 @@
 #include "gpio_input.h"
 #include "emu.h"
+#include "midi_input.h"
 
 #ifdef ESP_PLATFORM
 #include "driver/gpio.h"
@@ -66,6 +67,8 @@ int get_hid_gpio(uint8_t* dst) {
 int get_hid_all(uint8_t* dst) {
     int n = 0;
     if ((n = get_hid_gpio(dst)))
+        return n;
+    if ((n = get_hid_midi(dst)))
         return n;
     if ((n = get_hid_ir(dst)))
         return n;

--- a/src/midi_input.cpp
+++ b/src/midi_input.cpp
@@ -1,0 +1,104 @@
+#include "midi_input.h"
+#include "emu.h"
+#include "analog_glitch.h"
+
+#ifdef ESP_PLATFORM
+#include <Arduino.h>
+
+#define MIDI_RX_PIN 26
+#define MIDI_GLITCH_CC 1
+
+struct midi_button_state {
+    uint16_t current_state;
+    uint16_t last_state;
+};
+
+static midi_button_state _midi_buttons = {0};
+static uint8_t _running_status = 0;
+static uint8_t _data[2];
+static uint8_t _data_index = 0;
+
+static const uint8_t note_map[8] = {60,62,64,65,67,69,71,72};
+static const uint16_t button_map[8] = {
+    GENERIC_UP,
+    GENERIC_DOWN,
+    GENERIC_LEFT,
+    GENERIC_RIGHT,
+    GENERIC_FIRE_A,
+    GENERIC_FIRE_B,
+    GENERIC_START,
+    GENERIC_SELECT
+};
+
+static void handle_note(uint8_t note, bool on) {
+    for (int i = 0; i < 8; ++i) {
+        if (note_map[i] == note) {
+            if (on)
+                _midi_buttons.current_state |= button_map[i];
+            else
+                _midi_buttons.current_state &= ~button_map[i];
+            break;
+        }
+    }
+}
+
+static void handle_cc(uint8_t cc, uint8_t val) {
+    if (cc == MIDI_GLITCH_CC) {
+        uint8_t slot = (val * (GLITCH_SLOTS - 1)) / 127;
+        analog_glitch_set_slot(slot);
+    }
+}
+
+static void midi_parse(uint8_t b) {
+    if (b & 0x80) {
+        _running_status = b;
+        _data_index = 0;
+        return;
+    }
+    if (!_running_status)
+        return;
+    _data[_data_index++] = b;
+    if (_data_index >= 2) {
+        uint8_t status = _running_status & 0xF0;
+        if (status == 0x90 || status == 0x80) {
+            bool on = (status == 0x90) && _data[1] > 0;
+            handle_note(_data[0], on);
+        } else if (status == 0xB0) {
+            handle_cc(_data[0], _data[1]);
+        }
+        _data_index = 0;
+    }
+}
+
+static void midi_poll() {
+    while (Serial1.available()) {
+        uint8_t b = Serial1.read();
+        midi_parse(b);
+    }
+}
+
+void midi_input_init() {
+    Serial1.begin(31250, SERIAL_8N1, MIDI_RX_PIN, -1);
+}
+
+int get_hid_midi(uint8_t* dst) {
+    midi_poll();
+    if (_midi_buttons.current_state != _midi_buttons.last_state) {
+        _midi_buttons.last_state = _midi_buttons.current_state;
+        dst[0] = 0xA1;
+        dst[1] = 0x42;
+        dst[2] = _midi_buttons.current_state & 0xFF;
+        dst[3] = _midi_buttons.current_state >> 8;
+        dst[4] = 0;
+        dst[5] = 0;
+        return 6;
+    }
+    return 0;
+}
+
+#else
+
+void midi_input_init() {}
+int get_hid_midi(uint8_t* dst) { (void)dst; return 0; }
+
+#endif // ESP_PLATFORM

--- a/src/midi_input.h
+++ b/src/midi_input.h
@@ -1,0 +1,9 @@
+#ifndef MIDI_INPUT_H
+#define MIDI_INPUT_H
+
+#include <stdint.h>
+
+void midi_input_init();
+int get_hid_midi(uint8_t* dst);
+
+#endif // MIDI_INPUT_H


### PR DESCRIPTION
## Summary
- Map central C-major octave MIDI notes to standard button controls
- Route MIDI CC to analog glitch slots for remote glitch parameter control
- Wire MIDI input into existing HID processing alongside GPIO

## Testing
- `arduino-cli --version` *(fails: command not found)*
- `make` *(fails: No targets specified and no makefile found)*

------
https://chatgpt.com/codex/tasks/task_e_68b950e25df083238bad64fcdcda2d4f